### PR TITLE
5장 리펙토링

### DIFF
--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,5 +1,9 @@
 package webserver;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.FileUtils;
@@ -9,14 +13,9 @@ import webserver.http.HttpHeader;
 import webserver.http.HttpRequest;
 import webserver.http.HttpRequestMessage;
 import webserver.http.HttpResponse;
+import webserver.http.HttpResponseMessage;
 import webserver.http.HttpStatus;
 import webserver.was.Dispatcher;
-
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Socket;
 
 public class RequestHandler extends Thread {
 
@@ -40,6 +39,8 @@ public class RequestHandler extends Thread {
             HttpRequestMessage requestMessage = HttpRequestMessage.parse(in);
             String path = requestMessage.uri().getPath();
 
+            HttpResponseMessage httpResponseMessage = null;
+
             // 정적 요청 처리
             if (isStaticResourceRequest(path)) {
                 String extension = HttpRequestUtils.parseExtension(path);
@@ -49,16 +50,18 @@ public class RequestHandler extends Thread {
                 header.add("Content-Type", ContentType.findByExtension(extension).getHeader());
                 header.add("Content-Length", String.valueOf(file.length));
 
-                flush(out, new HttpResponse(HttpStatus.OK, header, file));
-                return;
+                httpResponseMessage = new HttpResponseMessage(out, new HttpResponse(HttpStatus.OK, header, file));
             }
 
             // 동적 요청 처리
             if (dispatcher.isMapped(requestMessage.method(), requestMessage.uri())) {
                 HttpRequest request = HttpRequest.from(requestMessage);
 
-                HttpResponse httpResponse = this.dispatcher.handlerRequest(request);
-                flush(out, httpResponse);
+                httpResponseMessage = new HttpResponseMessage(out, this.dispatcher.handlerRequest(request));
+            }
+
+            if (httpResponseMessage != null) {
+                httpResponseMessage.flush();
             }
         } catch (IOException e) {
             log.error(e.getMessage());
@@ -67,23 +70,5 @@ public class RequestHandler extends Thread {
 
     private boolean isStaticResourceRequest(String path) {
         return ContentType.isExistsByExtension(HttpRequestUtils.parseExtension(path));
-    }
-
-    private void flush(OutputStream out, HttpResponse response) {
-        try (DataOutputStream dos = new DataOutputStream(out)) {
-            HttpStatus status = response.getStatus();
-            HttpHeader header = response.getHeader();
-            byte[] body = response.getBody();
-
-            dos.writeBytes(String.format("HTTP/1.1 %d %s \r\n", status.getCode(), status.getStatus()));
-            for (String key : header.keySet()) {
-                dos.writeBytes(String.format("%s: %s\r\n", key, header.get(key)));
-            }
-            dos.writeBytes("\r\n");
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/main/java/webserver/http/HttpHeader.java
+++ b/src/main/java/webserver/http/HttpHeader.java
@@ -4,7 +4,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class HttpHeader{
+public class HttpHeader {
+
+    public static final String CONTENT_LENGTH = "Content-Length";
+
     private final Map<String, String> header = new HashMap<>();
 
     public void add(String key, String value) {

--- a/src/main/java/webserver/http/HttpRequestLine.java
+++ b/src/main/java/webserver/http/HttpRequestLine.java
@@ -1,0 +1,31 @@
+package webserver.http;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class HttpRequestLine {
+
+	private static final String SP = " ";
+	private static final int METHOD_INDEX = 0;
+	private static final int URI_INDEX = 1;
+
+	private final HttpMethod method;
+	private final URI uri;
+
+	public HttpRequestLine(String requestLine) {
+		Objects.requireNonNull(requestLine);
+
+		String[] splittedRequestLine = requestLine.split(SP);
+
+		this.method = HttpMethod.valueOf(splittedRequestLine[METHOD_INDEX]);
+		this.uri = URI.create(splittedRequestLine[URI_INDEX]);
+	}
+
+	public HttpMethod getMethod() {
+		return method;
+	}
+
+	public URI getUri() {
+		return uri;
+	}
+}

--- a/src/main/java/webserver/http/HttpRequestMessage.java
+++ b/src/main/java/webserver/http/HttpRequestMessage.java
@@ -1,5 +1,7 @@
 package webserver.http;
 
+import static webserver.http.HttpHeader.CONTENT_LENGTH;
+
 import util.HttpRequestUtils;
 import util.IOUtils;
 
@@ -11,7 +13,7 @@ import java.net.URI;
 
 public record HttpRequestMessage(HttpMethod method, URI uri, HttpHeader header, HttpRequestBody body) {
 
-    private static final String CONTENT_LENGTH = "Content-Length";
+
     private static final String SP = " ";
     private static final int METHOD_INDEX = 0;
     private static final int URI_INDEX = 1;

--- a/src/main/java/webserver/http/HttpResponseMessage.java
+++ b/src/main/java/webserver/http/HttpResponseMessage.java
@@ -1,0 +1,43 @@
+package webserver.http;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class HttpResponseMessage {
+
+	private final OutputStream out;
+	private final HttpResponse httpResponse;
+
+	public HttpResponseMessage(OutputStream out, HttpResponse httpResponse) {
+		this.out = out;
+		this.httpResponse = httpResponse;
+	}
+
+	public void flush() {
+		try (DataOutputStream dos = new DataOutputStream(out)) {
+			writeResponseLine(dos, httpResponse.getStatus());
+			writeResponseHeader(dos, httpResponse.getHeader());
+			dos.writeBytes("\r\n");
+			writeResponseBody(dos, httpResponse.getBody());
+
+			dos.flush();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void writeResponseLine(DataOutputStream dos, HttpStatus status) throws IOException {
+		dos.writeBytes(String.format("HTTP/1.1 %d %s\r\n", status.getCode(), status.getStatus()));
+	}
+
+	private void writeResponseHeader(DataOutputStream dos, HttpHeader header) throws IOException {
+		for (String key : header.keySet()) {
+			dos.writeBytes(String.format("%s: %s\r\n", key, header.get(key)));
+		}
+	}
+
+	private static void writeResponseBody(DataOutputStream dos, byte[] body) throws IOException {
+		dos.write(body, 0, body.length);
+	}
+}

--- a/src/test/java/webserver/http/HttpRequestLineTest.java
+++ b/src/test/java/webserver/http/HttpRequestLineTest.java
@@ -1,0 +1,44 @@
+package webserver.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestLineTest {
+
+	@Nested
+	@DisplayName("HttpRequestLine 를 생성할 때")
+	class Create {
+
+		@Test
+		void 정상적인_RequestLine_이_들어오면_객체가_생성된다() {
+		    // given
+			String requestLine = "GET /index.html HTTP/1.1";
+			HttpMethod expectedMethod = HttpMethod.GET;
+			URI expectedURI = URI.create("/index.html");
+
+		    // when
+			HttpRequestLine httpRequestLine = new HttpRequestLine(requestLine);
+
+			// then
+			assertThat(httpRequestLine).isNotNull();
+			assertThat(httpRequestLine.getMethod()).isEqualTo(expectedMethod);
+			assertThat(httpRequestLine.getUri()).isEqualTo(expectedURI);
+		}
+
+		@Test
+		void RequestLine_이_null_이면_예외가_발생한다() {
+		    // given
+			String requestLine = null;
+
+		    // then
+			assertThatThrownBy(() -> new HttpRequestLine(requestLine))
+				.isInstanceOf(NullPointerException.class);
+		}
+	}
+
+}

--- a/src/test/java/webserver/http/HttpResponseMessageTest.java
+++ b/src/test/java/webserver/http/HttpResponseMessageTest.java
@@ -1,0 +1,34 @@
+package webserver.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class HttpResponseMessageTest {
+
+	@Nested
+	@DisplayName("HttpResponseMessage 를 생성할 때")
+	class Create{
+
+		@Test
+		void 정적_파일_응답에는_응답출력을_성공한다() {
+		    // given
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			HttpStatus status = HttpStatus.OK;
+			String html = "<html><h1>안녕하세요</h1></html>";
+			String expectedResponse = "HTTP/1.1 200 OK\r\n\r\n<html><h1>안녕하세요</h1></html>";
+			HttpResponse httpResponse = new HttpResponse(status, new HttpHeader(), html.getBytes());
+
+			// when
+			HttpResponseMessage httpResponseMessage = new HttpResponseMessage(out, httpResponse);
+			httpResponseMessage.flush();
+
+			// then
+			String flushedResponseMessage = out.toString();
+			assertThat(flushedResponseMessage).isEqualTo(expectedResponse);
+		}
+	}
+}


### PR DESCRIPTION
### Description

리펙토링

### Commits

구현 사항 요약
1. `HttpRequestMessage` 클래스에 있던 `CONTENT_LENGTH` 헤더를 `HttpHeader` 클래스로 이동
2. `HttpRequestMessage` 에서 Http Request Line 파싱 로직을 `HttpRequestLine` 클래스로 분리
3. `RequestHandler` 에서 `HttpResponse` 출력 로직을 `HttpRequestMessage` 클래스로 분리